### PR TITLE
Update MedComMessagingProvenance.fsh

### DIFF
--- a/input/fsh/MedComMessagingProvenance.fsh
+++ b/input/fsh/MedComMessagingProvenance.fsh
@@ -3,8 +3,6 @@ Parent: Provenance
 Id: medcom-messaging-provenance
 Description: "Provenance information about the messages preceeding the current message"
 * target 1..1 MS
-* target ^definition = "Shall reference the message header being targeted."
-* target ^type.aggregation = #bundled
 * occurred[x] 1..
 * occurredDateTime 1.. MS
 * occurredDateTime ^short = "Date and Time the message was send"


### PR DESCRIPTION
Closes #136
Fixes Provenance.target.aggregation  to allow refference outside Bundle. 

## Test
```POST https://fhirdev.medcom.dk/fhir/Bundle/$validate?profile=http://medcomfhir.dk/fhir/core/1.0/StructureDefinition/medcom-hospitalNotification-message ```
[body] (http://build.fhir.org/ig/hl7dk/dk-medcom/branches/1.0.3-Provenance.target.aggregation-ANJ/Bundle-094de8ee-bd94-475e-b454-b8fbbef8a685.xml.html) with Provenance.target refference outside bundle. 
Expected: 200 OK response -no errors 